### PR TITLE
Add postinstall hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,18 @@ This library aims to complement [@daml/react](`https://www.npmjs.com/package/@da
 to make it easier to write [React](https://reactjs.org/) applications on DABL specifically.
 To that end we provide for convenience.
 
+## Install
+
+```
+yarn add digital-asset/dabl-react
+```
+
+or
+
+```
+npm install digital-asset/dabl-react
+```
+
 ## Usage
 
 ### Well Known End point
@@ -47,4 +59,3 @@ One of the Well Known parties, is the **Public** party that can be used to discl
 let usersPartyName = partyName(token);
 let needToResetLogin = expiredToken(token);
 ```
-

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "client",
     "API"
   ],
-  "main": "lib/index.js",
+  "main": "./lib/index.js",
+  "types": "./lib/index.d.ts",
   "license": "0BSD",
   "dependencies": {
     "@daml/react": "1.4.0",
@@ -18,11 +19,13 @@
     "@mojotech/json-type-validation": "^3.1.0",
     "@types/jsonwebtoken": "^8.5.0",
     "jsonwebtoken": "^8.5.1",
+    "typescript": "~3.8.3",
     "react": "^16.12.0"
   },
   "scripts": {
     "build": "tsc --build",
     "build:watch": "tsc --build --watch",
+    "postinstall": "tsc --build",
     "test": "jest",
     "lint": "eslint --ext .ts --ignore-pattern lib/ --max-warnings 0 ./"
   },
@@ -39,8 +42,7 @@
     "jest": "^26.1.0",
     "jest-fetch-mock": "^3.0.3",
     "react-test-renderer": "^16.12.0",
-    "ts-jest": "^26.1.1",
-    "typescript": "~3.8.3"
+    "ts-jest": "^26.1.1"
   },
   "jest": {
     "testEnvironment": "jsdom",


### PR DESCRIPTION
Projects may import the library via the GitHub repo, and `yarn` will run the postinstall build script automatically