### PR TITLE
retype public analogue hooks to match with latest @daml/react hook type definitions

### DIFF
--- a/PublicLedger.ts
+++ b/PublicLedger.ts
@@ -79,14 +79,10 @@ export function useFetchByKeyAsPublic<T extends object, K, I extends string>(tem
  *
  * @return The matching contracts.
  */
-export function useStreamQueryAsPublic<T extends object, K, I extends string>(template: Template<T, K, I>, queryFactory: () => Query<T>, queryDeps: readonly unknown[], closeHandler: (e: StreamCloseEvent) => void): QueryResult<T, K, I>
-export function useStreamQueryAsPublic<T extends object, K, I extends string>(template: Template<T, K, I>): QueryResult<T, K, I>
 export function useStreamQueryAsPublic<T extends object, K, I extends string>(template: Template<T, K, I>, queryFactory?: () => Query<T>, queryDeps?: readonly unknown[], closeHandler?: (e: StreamCloseEvent) => void): QueryResult<T, K, I> {
   return useStreamQuery(template, queryFactory, queryDeps, closeHandler);
 }
 
-export function useStreamQueriesAsPublic<T extends object, K, I extends string>(template: Template<T, K, I>, queryFactory: () => Query<T>[], queryDeps: readonly unknown[], closeHandler: (e: StreamCloseEvent) => void): QueryResult<T, K, I>
-export function useStreamQueriesAsPublic<T extends object, K, I extends string>(template: Template<T, K, I>): QueryResult<T, K, I>
 export function useStreamQueriesAsPublic<T extends object, K, I extends string>(template: Template<T, K, I>, queryFactory?: () => Query<T>[], queryDeps?: readonly unknown[], closeHandler?: (e: StreamCloseEvent) => void): QueryResult<T, K, I> {
   return useStreamQueries(template, queryFactory, queryDeps, closeHandler);
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@daml/hub-react",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Daml React functions for Daml Hub.",
   "homepage": "https://projectdabl.com",
   "keywords": [


### PR DESCRIPTION
As per https://github.com/digital-asset/daml/blob/104ad067ef06d0b342fb948178c6ff38193a0adc/language-support/ts/daml-react/createLedgerContext.ts#L231

Due to some type mismatches in the newest @daml/react hook definitions, there were some TS errors with using `useStreamQueriesAsPublic` that would not occur with `useStreamQueries`. 