### PR TITLE
Use a proper bash script for publishing instead of makefile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - test_steps
       - run:
-          command: make publish
+          command: ./publish.sh
 
   test_build_and_publish:
     executor:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,8 +24,6 @@ jobs:
       name: node/default
     steps:
       - test_steps
-      - run:
-          command: .circleci/publish.sh
 
   test_build_and_publish:
     executor:
@@ -40,7 +38,7 @@ jobs:
           command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > .npmrc
       - run:
           name: Publish package
-          command: make publish
+          command: .circleci/publish.sh
 
 workflows:
   test_library:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,8 @@ jobs:
       name: node/default
     steps:
       - test_steps
+      - run:
+          command: make publish
 
   test_build_and_publish:
     executor:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - test_steps
       - run:
-          command: ./publish.sh
+          command: .circleci/publish.sh
 
   test_build_and_publish:
     executor:

--- a/.circleci/publish.sh
+++ b/.circleci/publish.sh
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 GIT_TAG=$(git tag --contains)
+GIT_TAG="v1.0.0-rc.1"
 RELEASE_TAG="latest"
 
 if [[ "$GIT_TAG" = "" ]]

--- a/.circleci/publish.sh
+++ b/.circleci/publish.sh
@@ -3,8 +3,6 @@
 set -euo pipefail
 
 GIT_TAG=$(git tag --contains)
-GIT_TAG="v1.0.0-rc.1"
-RELEASE_TAG="latest"
 
 if [[ "$GIT_TAG" = "" ]]
 then
@@ -14,10 +12,11 @@ fi
 
 echo "Found git tag: '$GIT_TAG'..."
 
+RELEASE_TAG="latest"
 if [[ $GIT_TAG =~ ^v.*rc.* ]]
 then
     RELEASE_TAG="prerelease"
 fi
 
 echo "Publishing with '--tag $RELEASE_TAG'..."
-npm publish --access public --tag $RELEASE_TAG --dry-run
+npm publish --access public --tag $RELEASE_TAG

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-GIT_TAG := 1.0.0
+GIT_TAG := 1.0.0-rc.1
 RELEASE_TAG := $(shell MATCHES=$$(expr $(GIT_TAG) : '*rc*'); if [ $$MATCHES -ne 0 ]; then echo 'prerelease'; else echo 'latest'; fi)
 
 .PHONY: publish

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,0 @@
-GIT_TAG := 1.0.0-rc.1
-MATCHES := $(shell expr $(GIT_TAG) : '*rc*')
-RELEASE_TAG := $(shell if [ "$(MATCHES)" = "0" ]; then echo 'latest'; else echo 'prerelease'; fi)
-
-.PHONY: publish
-publish:
-	npm publish --access public --tag $(RELEASE_TAG) --dry-run

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-GIT_TAG := $(shell git tag --contains)
-RELEASE_TAG := $(shell [[ $(GIT_TAG) =~ ^.*rc.* ]] && echo 'prerelease' || echo 'latest')
+GIT_TAG := 1.0.0
+RELEASE_TAG := $(shell MATCHES=$$(expr $(GIT_TAG) : '*rc*'); if [ $$MATCHES -ne 0 ]; then echo 'prerelease'; else echo 'latest'; fi)
 
 .PHONY: publish
 publish:
-	npm publish --access public --tag $(RELEASE_TAG)
+	npm publish --access public --tag $(RELEASE_TAG) --dry-run

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 GIT_TAG := 1.0.0-rc.1
 MATCHES := $(shell expr $(GIT_TAG) : '*rc*')
-RELEASE_TAG := $(shell if [ $(MATCHES) -ne 0 ]; then echo 'prerelease'; else echo 'latest'; fi)
+RELEASE_TAG := $(shell if [ "$(MATCHES)" = "0" ]; then echo 'latest'; else echo 'prerelease'; fi)
 
 .PHONY: publish
 publish:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 GIT_TAG := 1.0.0-rc.1
-RELEASE_TAG := $(shell MATCHES=$$(expr $(GIT_TAG) : '*rc*'); if [ $$MATCHES -ne 0 ]; then echo 'prerelease'; else echo 'latest'; fi)
+MATCHES := $(shell expr $(GIT_TAG) : '*rc*')
+RELEASE_TAG := $(shell if [ $(MATCHES) -ne 0 ]; then echo 'prerelease'; else echo 'latest'; fi)
 
 .PHONY: publish
 publish:

--- a/publish.sh
+++ b/publish.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 GIT_TAG=$(git tag --contains)
-GIT_TAG=1.0.0-rc.1
+GIT_TAG=v1.0.0-rc.1
 RELEASE_TAG="latest"
 
 if [[ $GIT_TAG =~ ^v.*rc.* ]]

--- a/publish.sh
+++ b/publish.sh
@@ -5,18 +5,18 @@ set -euo pipefail
 GIT_TAG=$(git tag --contains)
 RELEASE_TAG="latest"
 
-if [[ -n $GIT_TAG ]]
+if [[ "$GIT_TAG" = "" ]]
 then
     echo "No git tag found! Aborting..."
     exit 1
 fi
 
-echo "Found git tag: $GIT_TAG..."
+echo "Found git tag: '$GIT_TAG'..."
 
 if [[ $GIT_TAG =~ ^v.*rc.* ]]
 then
     RELEASE_TAG="prerelease"
 fi
 
-echo "Publishing with `--tag $RELEASE_TAG...`"
+echo "Publishing with '--tag $RELEASE_TAG'..."
 npm publish --access public --tag $RELEASE_TAG --dry-run

--- a/publish.sh
+++ b/publish.sh
@@ -3,15 +3,20 @@
 set -euo pipefail
 
 GIT_TAG=$(git tag --contains)
-GIT_TAG=v1.0.0-rc.1
 RELEASE_TAG="latest"
 
-echo "Found git tag $GIT_TAG..."
+if [[ $GIT_TAG -n ]]
+then
+    echo "No git tag found! Aborting..."
+    exit 1
+fi
+
+echo "Found git tag: $GIT_TAG..."
 
 if [[ $GIT_TAG =~ ^v.*rc.* ]]
 then
     RELEASE_TAG="prerelease"
 fi
 
-echo "Publishing as $RELEASE_TAG..."
+echo "Publishing with `--tag $RELEASE_TAG...`"
 npm publish --access public --tag $RELEASE_TAG --dry-run

--- a/publish.sh
+++ b/publish.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 GIT_TAG=$(git tag --contains)
 RELEASE_TAG="latest"
 
-if [[ $GIT_TAG -n ]]
+if [[ -n $GIT_TAG ]]
 then
     echo "No git tag found! Aborting..."
     exit 1

--- a/publish.sh
+++ b/publish.sh
@@ -10,4 +10,5 @@ then
     $RELEASE_TAG="prerelease"
 fi
 
+echo "Publishing as $RELEASE_TAG..."
 npm publish --access public --tag $RELEASE_TAG --dry-run

--- a/publish.sh
+++ b/publish.sh
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 GIT_TAG=$(git tag --contains)
+GIT_TAG=1.0.0-rc.1
 RELEASE_TAG="latest"
 
 if [[ $GIT_TAG =~ ^v.*rc.* ]]

--- a/publish.sh
+++ b/publish.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+GIT_TAG=$(git tag --contains)
+RELEASE_TAG="latest"
+
+if [[ $GIT_TAG =~ ^v.*rc.* ]]
+then
+    $RELEASE_TAG="prerelease"
+fi
+
+npm publish --access public --tag $RELEASE_TAG --dry-run

--- a/publish.sh
+++ b/publish.sh
@@ -6,9 +6,11 @@ GIT_TAG=$(git tag --contains)
 GIT_TAG=v1.0.0-rc.1
 RELEASE_TAG="latest"
 
+echo "Found git tag $GIT_TAG..."
+
 if [[ $GIT_TAG =~ ^v.*rc.* ]]
 then
-    $RELEASE_TAG="prerelease"
+    RELEASE_TAG="prerelease"
 fi
 
 echo "Publishing as $RELEASE_TAG..."


### PR DESCRIPTION
PR #25, while working on my machine, ended up not working in CI, because make was running in a `sh` environment instead of `bash`, which doesn't understand `[[` style tests. 

I moved this into a proper bash script for compatibility, and some other improvements (i.e., failing if no git tag is found)

This one I actually tested in circleci's environment directly by modifying the config on _this_ branch to run the script and checking that it succeeds all the way (with a --dry-run scenario)! (https://app.circleci.com/pipelines/github/digital-asset/dabl-react/102/workflows/e05a1419-90f6-4f4c-8676-5835d23071dd/jobs/117) 

It works! 