### PR TITLE
Login fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@daml/hub-react",
-  "version": "1.0.0-rc.2",
+  "version": "1.0.0-rc.3",
   "description": "Daml React functions for Daml Hub",
   "homepage": "https://hub.daml.com",
   "keywords": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ export { DefaultParties } from './default-parties/defaultParties';
 
 export { Automation, Instance } from './automation/automation';
 
-export { convertPartiesJson } from './login/PartiesInput';
+export { convertPartiesJson, InvalidPartiesError, PartiesInputErrors } from './login/PartiesInput';
 export { DamlHubLogin, damlHubLogout } from './login/DamlHubLogin';
 
 export { isRunningOnHub, damlHubEnvironment } from './utils';


### PR DESCRIPTION
Works around a Daml Hub bug where apps hosted on *.projectdabl.com sometimes get back cookie tokens for a different ledger. 

If a token contains a different ledger ID than the one the *.projectdabl.com domain is running on, then we invalidate the cookies automatically. 

Also exports the custom error class in parties.json validation for users to use 