### PR TITLE
Drop typescript-logging for custom console wrapper

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@daml/hub-react",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Daml React functions for Daml Hub",
   "homepage": "https://hub.daml.com",
   "keywords": [
@@ -18,8 +18,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@mojotech/json-type-validation": "^3.1.0",
-    "jsonwebtoken": "^8.5.1",
-    "typescript-logging": "^1.0.0"
+    "jsonwebtoken": "^8.5.1"
   },
   "repository": "github:digital-asset/dabl-react",
   "scripts": {

--- a/src/log.ts
+++ b/src/log.ts
@@ -1,18 +1,27 @@
-import {
-  LFService,
-  LoggerFactory,
-  LoggerFactoryOptions,
-  LogGroupRule,
-  LogLevel,
-} from 'typescript-logging';
+type LogLevel = 'log' | 'info' | 'debug' | 'warn' | 'error';
 
-const logPrefix = 'damlhub-react';
+function prefixLog(name: string, logLevel: LogLevel) {
+  return `${logLevel.toUpperCase()} [damlhub-react:${name}]`;
+}
 
-const options = new LoggerFactoryOptions();
-options.addLogGroupRule(new LogGroupRule(new RegExp(`${logPrefix}.+`), LogLevel.Info));
-
-const factory: LoggerFactory = LFService.createNamedLoggerFactory('LoggerFactory', options);
+type LogData = (string | number | object)[];
 
 export default (name: string) => {
-  return factory.getLogger(`${logPrefix}:${name}`);
+  return {
+    debug: (...data: LogData) => {
+      console.debug(prefixLog(name, 'debug'), ...data);
+    },
+    log: (...data: LogData) => {
+      console.log(prefixLog(name, 'log'), ...data);
+    },
+    info: (...data: LogData) => {
+      console.info(prefixLog(name, 'info'), ...data);
+    },
+    warn: (...data: LogData) => {
+      console.warn(prefixLog(name, 'warn'), ...data);
+    },
+    error: (...data: LogData) => {
+      console.error(prefixLog(name, 'error'), ...data);
+    },
+  };
 };

--- a/src/login/DamlHubLogin.tsx
+++ b/src/login/DamlHubLogin.tsx
@@ -139,7 +139,7 @@ const ButtonLogin: React.FC<DamlHubLoginProps> = props => {
 
     log('button-login:effect').info(
       !!tokenFromCookie
-        ? `Found token in browser cookie: ${tokenFromCookie}`
+        ? `Found token in browser cookie`
         : 'No cookie found - user has not authenticated'
     );
 
@@ -181,7 +181,7 @@ const ButtonLogin: React.FC<DamlHubLoginProps> = props => {
 
     log('button-login:click-handler').info(
       !!tokenFromCookie
-        ? `Found token in browser cookie: ${tokenFromCookie}`
+        ? `Found token in browser cookie`
         : 'No cookie found - user has not authenticated'
     );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1532,13 +1532,6 @@ error-ex@^1.3.1:
   dependencies:
     is-arrayish "^0.2.1"
 
-error-stack-parser@^1.3.6:
-  version "1.3.6"
-  resolved "https://registry.yarnpkg.com/error-stack-parser/-/error-stack-parser-1.3.6.tgz#e0e73b93e417138d1cd7c0b746b1a4a14854c292"
-  integrity sha1-4Oc7k+QXE40c18C3RrGkoUhUwpI=
-  dependencies:
-    stackframe "^0.3.1"
-
 escalade@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
@@ -3825,11 +3818,6 @@ source-map-url@^0.4.0:
   resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.1.tgz#0af66605a745a5a2f91cf1bbf8a7afbc283dec56"
   integrity sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==
 
-source-map@0.5.6:
-  version "0.5.6"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
-  integrity sha1-dc449SvwczxafwwRjYEzSiu19BI=
-
 source-map@^0.5.0, source-map@^0.5.6:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
@@ -3883,46 +3871,12 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
-stack-generator@^1.0.7:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/stack-generator/-/stack-generator-1.1.0.tgz#36f6a920751a6c10f499a13c32cbb5f51a0b8b25"
-  integrity sha1-NvapIHUabBD0maE8Msu19RoLiyU=
-  dependencies:
-    stackframe "^1.0.2"
-
 stack-utils@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-2.0.3.tgz#cd5f030126ff116b78ccb3c027fe302713b61277"
   integrity sha512-gL//fkxfWUsIlFL2Tl42Cl6+HFALEaB1FU76I/Fy+oZjRreP7OPMXFlGbxM7NQsI0ZpUfw76sHnv0WNYuTb7Iw==
   dependencies:
     escape-string-regexp "^2.0.0"
-
-stackframe@^0.3.1, stackframe@~0.3:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/stackframe/-/stackframe-0.3.1.tgz#33aa84f1177a5548c8935533cbfeb3420975f5a4"
-  integrity sha1-M6qE8Rd6VUjIk1Uzy/6zQgl19aQ=
-
-stackframe@^1.0.2:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/stackframe/-/stackframe-1.2.0.tgz#52429492d63c62eb989804c11552e3d22e779303"
-  integrity sha512-GrdeshiRmS1YLMYgzF16olf2jJ/IzxXY9lhKOskuVziubpTYcYqyOwYeJKzQkwy7uN0fYSsbsC4RQaXf9LCrYA==
-
-stacktrace-gps@^2.4.3:
-  version "2.4.4"
-  resolved "https://registry.yarnpkg.com/stacktrace-gps/-/stacktrace-gps-2.4.4.tgz#69c827e9d6d6f41cf438d7f195e2e3cbfcf28c44"
-  integrity sha1-acgn6dbW9Bz0ONfxleLjy/zyjEQ=
-  dependencies:
-    source-map "0.5.6"
-    stackframe "~0.3"
-
-stacktrace-js@1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/stacktrace-js/-/stacktrace-js-1.3.1.tgz#67cab2589af5c417b962f7369940277bb3b6a18b"
-  integrity sha1-Z8qyWJr1xBe5Yvc2mUAne7O2oYs=
-  dependencies:
-    error-stack-parser "^1.3.6"
-    stack-generator "^1.0.7"
-    stacktrace-gps "^2.4.3"
 
 static-extend@^0.1.1:
   version "0.1.2"
@@ -4187,13 +4141,6 @@ typedarray-to-buffer@^3.1.5:
   integrity sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==
   dependencies:
     is-typedarray "^1.0.0"
-
-typescript-logging@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/typescript-logging/-/typescript-logging-1.0.0.tgz#efc42ae828de4a35e1a941234a94e119322b5ad1"
-  integrity sha512-qeHtadCVKOt6ju4Ts20FgWRdlISditeTuplRlNTA+gFy7ENVK3czZ7YCET7yOZSZVnU00R+hGwls4dZv3+IBSg==
-  dependencies:
-    stacktrace-js "1.3.1"
 
 typescript@~3.8.3:
   version "3.8.3"


### PR DESCRIPTION
I've found that `typescript-logging` still emits `debug` logs onto standard INFO / LOG output in both Firefox and Chrome devtools, and ultimately decided that there's really no need for an external logging lib