### PR TITLE
Avoid initial delay when polling

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -118,6 +118,7 @@ export const usePolling = (fn: () => Promise<void>, interval: number) => {
       log('polling').debug('Disabling polling, app is not running on Daml Hub');
       return () => {};
     } else if (interval > 0) {
+      fn();
       let intervalID = setInterval(fn, interval);
       return () => clearInterval(intervalID);
     } else {


### PR DESCRIPTION
Note that this does not wait for the promise to complete before
starting the timer. That wasn’t the case for the later executions
either though so it’s consistent.