### PR TITLE
add canton public party type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@daml/hub-react",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Daml React functions for Daml Hub",
   "homepage": "https://hub.daml.com",
   "keywords": [

--- a/src/login/PartiesInput.tsx
+++ b/src/login/PartiesInput.tsx
@@ -57,7 +57,9 @@ function validateParties(parties: PartyDetails[], publicPartyId: string): void {
   }
 
   // True if any ledgerIds do not match the app's deployed ledger Id
-  const givenPublicParty = parties.find(p => p.party.includes('public-'));
+  const givenPublicParty = parties.find(
+    p => p.party.includes('public-') || p.party.includes('public::')
+  );
 
   if (!givenPublicParty) {
     throw new InvalidPartiesError(


### PR DESCRIPTION
This fixes an error when uploading the `parties.json` on Canton ledgers where it would not recognize the new Public party.