### PR TITLE
remove legacy domain

### DIFF
--- a/src/default-parties/defaultParties.ts
+++ b/src/default-parties/defaultParties.ts
@@ -1,12 +1,4 @@
-import {
-  array,
-  boolean,
-  Decoder,
-  number,
-  object,
-  optional,
-  string,
-} from '@mojotech/json-type-validation';
+import { array, boolean, Decoder, number, object, string } from '@mojotech/json-type-validation';
 
 import log from '../log';
 import { detectAppDomainType, DomainType } from '../utils';
@@ -19,16 +11,6 @@ interface PartyDetails {
   identifier: string;
   isLocal: boolean;
 }
-
-interface LegacyAPIResponse {
-  userAdminParty?: string;
-  publicParty: string;
-}
-
-const legacyAPIDecoder: Decoder<LegacyAPIResponse> = object({
-  userAdminParty: optional(string()),
-  publicParty: string(),
-});
 
 interface AppAPIResponse {
   result: PartyDetails[];
@@ -64,11 +46,6 @@ export async function fetchDefaultParties(): Promise<DefaultParties> {
           getPartyIdByName(app_parties.result, PUBLIC_DISPLAY_NAME),
           getPartyIdByName(app_parties.result, USER_ADMIN_DISPLAY_NAME),
         ];
-      case DomainType.LEGACY_DOMAIN:
-        const legacy_response = await fetch(`//${hn}/.well-known/dabl.json`);
-        const legacy_json = await legacy_response.json();
-        const legacy_parties = legacyAPIDecoder.runWithException(legacy_json);
-        return [legacy_parties.publicParty, legacy_parties.userAdminParty];
       default:
         throw new Error('App not running on Daml Hub');
     }

--- a/src/default-parties/publicToken.ts
+++ b/src/default-parties/publicToken.ts
@@ -20,17 +20,6 @@ export async function fetchPublicToken(): Promise<string | null> {
         const app_json = await app_response.json();
         const app_public = publicTokenDecoder.runWithException(app_json);
         return app_public.access_token;
-      case DomainType.LEGACY_DOMAIN:
-        const ledgerId = window.location.hostname.split('.')[0];
-        const legacy_response = await fetch(
-          `https://api.${hn.split('.').slice(1).join('.')}/api/ledger/${ledgerId}/public/token`,
-          {
-            method: 'POST',
-          }
-        );
-        const legacy_json = await legacy_response.json();
-        const legacy_public = publicTokenDecoder.runWithException(legacy_json);
-        return legacy_public.access_token;
       default:
         throw new Error('App not running on Daml Hub');
     }

--- a/src/login/DamlHubLogin.tsx
+++ b/src/login/DamlHubLogin.tsx
@@ -29,12 +29,7 @@ interface LoginOptions {
 }
 
 export const damlHubLogout = (): void => {
-  const hostname = damlHubEnvironment()?.hostname || 'projectdabl.com';
-
-  if (detectAppDomainType() === DomainType.LEGACY_DOMAIN) {
-    deleteCookie(DABL_LEDGER_ACCESS_TOKEN, hostname);
-    deleteCookie(DAMLHUB_LEDGER_ACCESS_TOKEN, hostname);
-  } else if (detectAppDomainType() === DomainType.APP_DOMAIN) {
+  if (detectAppDomainType() === DomainType.APP_DOMAIN) {
     deleteCookie(DAMLHUB_LEDGER_ACCESS_TOKEN);
   }
 };
@@ -143,30 +138,10 @@ const ButtonLogin: React.FC<DamlHubLoginProps> = props => {
         : 'No cookie found - user has not authenticated'
     );
 
-    const hubEnv = damlHubEnvironment();
-    const ledgerId = hubEnv?.ledgerId;
-
     if (tokenFromCookie) {
-      if (detectAppDomainType() === DomainType.LEGACY_DOMAIN) {
-        const url = new URL(window.location.toString());
-        url.search = '';
-        window.history.replaceState(window.history.state, '', url.toString());
-      }
-
       try {
         const at = new PartyToken(tokenFromCookie);
-        if (
-          !!ledgerId &&
-          ledgerId !== at.ledgerId &&
-          detectAppDomainType() === DomainType.LEGACY_DOMAIN
-        ) {
-          log('button-login:effect').warn(
-            `Token's ledger ID (${at.ledgerId}) does not match the current running ledger's ID of ${ledgerId}. Deleting cookies...`
-          );
-          damlHubLogout();
-        } else {
-          onLogin && onLogin(at);
-        }
+        onLogin && onLogin(at);
       } catch (error) {
         onLogin && onLogin(undefined, JSON.stringify(error));
       }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,17 +4,13 @@ import log from './log';
 
 export enum DomainType {
   APP_DOMAIN,
-  LEGACY_DOMAIN,
   NON_HUB_DOMAIN,
 }
 
 export const detectAppDomainType = (): DomainType => {
   const { hostname: hn } = window.location;
 
-  if (hn.includes('projectdabl') && hn.includes('.com')) {
-    log('domain').debug('App running on legacy projectdabl.com domain');
-    return DomainType.LEGACY_DOMAIN;
-  } else if (hn.includes('daml') && hn.includes('.app')) {
+  if (hn.includes('daml') && hn.includes('.app')) {
     log('domain').debug('App running on daml.app domain');
     return DomainType.APP_DOMAIN;
   } else {
@@ -39,10 +35,7 @@ export const damlHubEnvironment = ():
     }
   | undefined => {
   const hostname = window.location.hostname.split('.').slice(1).join('.');
-  const ledgerId =
-    detectAppDomainType() === DomainType.LEGACY_DOMAIN
-      ? window.location.hostname.split('.')[0]
-      : undefined;
+  const ledgerId = undefined;
   const baseURL = hubBaseURL();
   const wsURL = hubWsURL();
 
@@ -50,27 +43,13 @@ export const damlHubEnvironment = ():
 };
 
 const hubBaseURL = (): string | undefined => {
-  if (detectAppDomainType() === DomainType.APP_DOMAIN) {
-    return `${window.location.origin}/`;
-  } else if (detectAppDomainType() === DomainType.LEGACY_DOMAIN) {
-    const ledgerId = window.location.hostname.split('.')[0];
-    const hubHostname = window.location.hostname.split('.').slice(1).join('.');
-    return `https://api.${hubHostname}/data/${ledgerId}/`;
-  } else {
-    return undefined;
-  }
+  return detectAppDomainType() === DomainType.APP_DOMAIN ? `${window.location.origin}/` : undefined;
 };
 
 const hubWsURL = (): string | undefined => {
-  if (detectAppDomainType() === DomainType.APP_DOMAIN) {
-    return `wss://${window.location.hostname}/`;
-  } else if (detectAppDomainType() === DomainType.LEGACY_DOMAIN) {
-    const ledgerId = window.location.hostname.split('.')[0];
-    const hubHostname = window.location.hostname.split('.').slice(1).join('.');
-    return `wss://api.${hubHostname}/data/${ledgerId}/`;
-  } else {
-    return undefined;
-  }
+  return detectAppDomainType() === DomainType.APP_DOMAIN
+    ? `wss://${window.location.hostname}/`
+    : undefined;
 };
 
 /**


### PR DESCRIPTION
Daml Hub no longer hosts Apps on `projectdabl.com`.

This is a fully mechanical refactor driven completely by the removal of `DomainType.LEGACY_DOMAIN`, and then removing all the resulting dead code branches until the compile was happy 🙂 