### PR TITLE
allow 127.0.0.1 as localhost

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@daml/hub-react",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Daml React functions for Daml Hub",
   "homepage": "https://hub.daml.com",
   "keywords": [

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -14,7 +14,7 @@ export const detectAppDomainType = (): DomainType => {
   if (hn.includes('daml') && hn.includes('.app')) {
     log('domain').debug('App running on daml.app domain');
     return DomainType.APP_DOMAIN;
-  } else if (hn.includes('localhost')) {
+  } else if (hn.includes('localhost') || /^127(\.\d{1,3}){3}$/.exec(hn)) {
     log('domain').debug('App running on localhost');
     return DomainType.LOCALHOST;
   } else {


### PR DESCRIPTION
This adds `127.0.0.1` as a possible `hostname` for `DomainType.LOCALHOST`. It should fix the issues the `daml` repo is having with their compatibility tests.