### PR TITLE
Custom domain flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,14 +220,16 @@ let needToResetLogin = token.isExpired;
 
 // The original JWT string
 let jwt = token.token;
-
 ```
 
 ### Using hub-react with a custom domain
 
 If you are using this library with a domain that is not provided to you by Daml Hub, you must set `nonHubDomain` to `true` in the `DamlHub` context:
+
 ```tsx
-<DamlHub token='...' nonHubDomain>{/ ... /}</DamlHub>
+<DamlHub token="..." nonHubDomain>
+  {/ ... /}
+</DamlHub>
 ```
 
 You must also indicate this by passing `true` into `isRunningOnHub` if calling it directly.

--- a/README.md
+++ b/README.md
@@ -220,7 +220,17 @@ let needToResetLogin = token.isExpired;
 
 // The original JWT string
 let jwt = token.token;
+
 ```
+
+### Using hub-react with a custom domain
+
+If you are using this library with a domain that is not provided to you by Daml Hub, you must set `nonHubDomain` to `true` in the `DamlHub` context:
+```tsx
+<DamlHub token='...' nonHubDomain>{/ ... /}</DamlHub>
+```
+
+You must also indicate this by passing `true` into `isRunningOnHub` if calling it directly.
 
 ## Build
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@daml/hub-react",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Daml React functions for Daml Hub",
   "homepage": "https://hub.daml.com",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@daml/hub-react",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Daml React functions for Daml Hub",
   "homepage": "https://hub.daml.com",
   "keywords": [

--- a/src/automation/context.ts
+++ b/src/automation/context.ts
@@ -35,7 +35,7 @@ export const AutomationsProvider: React.FC<AutomationsProviderProps> = ({
   partyToken,
   publicToken,
   interval,
-  nonHubDomain = false
+  nonHubDomain = false,
 }) => {
   const [automations, setAutomations] = React.useState<Automation[]>();
   const [instances, setInstances] = React.useState<Instance[]>();

--- a/src/automation/context.ts
+++ b/src/automation/context.ts
@@ -24,6 +24,7 @@ interface AutomationsProviderProps {
   publicToken?: PartyToken | string;
   partyToken?: PartyToken | string;
   interval: number;
+  nonHubDomain?: boolean;
 }
 
 // This empty default context value does not escape outside of the provider.
@@ -34,6 +35,7 @@ export const AutomationsProvider: React.FC<AutomationsProviderProps> = ({
   partyToken,
   publicToken,
   interval,
+  nonHubDomain = false
 }) => {
   const [automations, setAutomations] = React.useState<Automation[]>();
   const [instances, setInstances] = React.useState<Instance[]>();
@@ -45,7 +47,7 @@ export const AutomationsProvider: React.FC<AutomationsProviderProps> = ({
       setAutomations(automations);
     }
   }, [publicToken, setAutomations]);
-  usePolling(pollAutomations, interval);
+  usePolling(pollAutomations, interval, nonHubDomain);
 
   const pollInstances = React.useCallback(async () => {
     // List running automation instances
@@ -54,7 +56,7 @@ export const AutomationsProvider: React.FC<AutomationsProviderProps> = ({
       setInstances(instances);
     }
   }, [partyToken, setInstances]);
-  usePolling(pollInstances, interval);
+  usePolling(pollInstances, interval, nonHubDomain);
 
   const undeployAutomationWrapper = !!partyToken
     ? async (artifactHash: string) => {

--- a/src/context/DamlHub.tsx
+++ b/src/context/DamlHub.tsx
@@ -25,7 +25,12 @@ interface DamlHubProps {
 // This empty default context value does not escape outside of the provider.
 const DamlHubContext = createContext<DamlHubCtx | undefined>(undefined);
 
-export const DamlHub: React.FC<DamlHubProps> = ({ children, token, interval: _i, nonHubDomain = false }) => {
+export const DamlHub: React.FC<DamlHubProps> = ({
+  children,
+  token,
+  interval: _i,
+  nonHubDomain = false,
+}) => {
   const [partyToken, setPartyToken] = React.useState<PartyToken>();
   const [publicToken, setPublicToken] = React.useState<PartyToken>();
   const [publicParty, setPublicParty] = React.useState<string>();

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -14,7 +14,7 @@ export const detectAppDomainType = (): DomainType => {
   if (hn.includes('daml') && hn.includes('.app')) {
     log('domain').debug('App running on daml.app domain');
     return DomainType.APP_DOMAIN;
-  } else if (hn.includes('localhost')) {
+  } else if (hn.includes('localhost') || /^127(\.\d{1,3}){3}$/.exec(hn)) {
     log('domain').debug('App running on localhost');
     return DomainType.LOCALHOST;
   } else {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -33,7 +33,9 @@ export const detectAppDomainType = (): DomainType => {
  *
  * Returns undefined if not running on Hub
  */
-export const damlHubEnvironment = (nonHubDomain: boolean = false):
+export const damlHubEnvironment = (
+  nonHubDomain: boolean = false
+):
   | {
       hostname: string;
       baseURL: string | undefined;
@@ -104,7 +106,11 @@ export const asyncFileReader = (file: File): Promise<string> => {
   });
 };
 
-export const usePolling = (fn: () => Promise<void>, interval: number, nonHubDomain: boolean = false) => {
+export const usePolling = (
+  fn: () => Promise<void>,
+  interval: number,
+  nonHubDomain: boolean = false
+) => {
   React.useEffect(() => {
     if (!isRunningOnHub(nonHubDomain)) {
       log('polling').debug('Disabling polling, app is not running on Daml Hub');


### PR DESCRIPTION
Currently, `isRunningOnHub` uses the hostname to decide if an app is running on hub - if `daml.app` is somewhere in there, it assumes it's running on hub. In a previous PR we made it possible for users of the library to run their ledger on hub using a custom non-hub domain. 

Unfortunately, this means that if the library is used in an app, and it is _not_ always meant to be running on hub (as is the case with the `create-daml-app` and derived apps), there no longer is enough information purely in the hostname to decide whether or not the library should assume it's running on hub. 

This PR solves that by making using a non-hub domain opt-in, assuming that if the domain doesn't look like a hub domain, it isn't meant to be running on Hub unless told otherwise.

This should fix remaining compatibility issues with `create-daml-app`.